### PR TITLE
FAI-5898: Make the graph version optional and defer to events API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {
 import pino from 'pino';
 
 export const DEFAULT_GRAPH_NAME = 'default';
-export const DEFAULT_GRAPH_VERSION = 'v2';
+export const DEFAULT_GRAPH_VERSION = 'v1';
 export const DEFAULT_ORIGIN = 'faros-test-results-reporter';
 export const DEFAULT_API_URL = 'https://prod.api.faros.ai';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,9 +10,13 @@ import {
 import pino from 'pino';
 
 export const DEFAULT_GRAPH_NAME = 'default';
-export const DEFAULT_GRAPH_VERSION = 'v1';
 export const DEFAULT_ORIGIN = 'faros-test-results-reporter';
 export const DEFAULT_API_URL = 'https://prod.api.faros.ai';
+
+enum GraphVersion {
+  V1 = 'v1',
+  V2 = 'v2',
+}
 
 /** The main entry point. */
 export function mainCommand(): Command {
@@ -57,7 +61,7 @@ export function mainCommand(): Command {
   const graphVersion = new Option(
     '--graph-version <version>',
     'The graph version that the test results should be sent to'
-  ).default(DEFAULT_GRAPH_VERSION);
+  ).choices(Object.values(GraphVersion))
   cmd.addOption(graphVersion);
 
   const origin = new Option(

--- a/src/test-results-reporter.ts
+++ b/src/test-results-reporter.ts
@@ -118,7 +118,7 @@ export class TestResultsReporter {
               custom: 0,
               total: ts.total,
             },
-            startTime: ts.timestamp ?? this.config.testStart,
+            startTime: ts.timestamp || this.config.testStart,
             endTime: ts.timestamp
               ? new Date(Date.parse(ts.timestamp) + ts.duration).toISOString()
               : this.config.testEnd,

--- a/src/test-results-reporter.ts
+++ b/src/test-results-reporter.ts
@@ -137,6 +137,10 @@ export class TestResultsReporter {
                 id,
                 JSON.stringify(data)
               );
+              const headers = this.config.graphVersion
+                ? {'x-faros-graph-version': this.config.graphVersion}
+                : undefined;
+
               await this.client.post(
                 `/graphs/${this.config.graph}/events`,
                 data,
@@ -145,9 +149,7 @@ export class TestResultsReporter {
                     full: true,
                     validateOnly: this.config.validateOnly,
                   },
-                  headers: {
-                    'x-faros-graph-version': this.config.graphVersion,
-                  },
+                  headers,
                 }
               );
               this.log.debug('Delivered event %s', id);


### PR DESCRIPTION
- Fix nullish coalescing to accept all false values for string including ''. ?? only checks if it is null or undefined
- Make the graph version totally optional here and defer to how the events CLI handles it